### PR TITLE
SUPPORT-9472: Updated the annotations to allow string|null

### DIFF
--- a/src/MessageMediaMessagesClient.php
+++ b/src/MessageMediaMessagesClient.php
@@ -11,8 +11,8 @@ class MessageMediaMessagesClient
 {
     /**
      * Constructor with authentication and configuration parameters
-     * @param null $authUserName
-     * @param null $authPassword
+     * @param string|null $authUserName
+     * @param string|null $authPassword
      * @param bool $useHmacAuthentication
      */
     public function __construct(


### PR DESCRIPTION
Updated the annotations to allow string|null for both $authUserName and $authPassword